### PR TITLE
Feat#3 session badges

### DIFF
--- a/src/Common.sol
+++ b/src/Common.sol
@@ -38,9 +38,10 @@ struct Attestation {
 
 /// @notice A struct representing a single Session.
 struct Session {
-  bytes32 uid; // A unique identifier of the sessão.
-  uint64 startTime; // The time when the session was created (Unix timestamp).
-  uint64 endTime; // The time when the session was ended (Unix timestamp).
+  address host; // Host of the session
+  string title; // Title of the session
+  uint256 startTime; // The time when the session was created (Unix timestamp).
+  uint256 endTime; // The time when the session was ended (Unix timestamp).
 }
 
 /// @notice A helper function to work with unchecked iterators in loops.

--- a/src/Common.sol
+++ b/src/Common.sol
@@ -36,6 +36,13 @@ struct Attestation {
   bytes data; // Custom attestation data.
 }
 
+/// @notice A struct representing a single Session.
+struct Session {
+  bytes32 uid; // A unique identifier of the sessão.
+  uint64 startTime; // The time when the session was created (Unix timestamp).
+  uint64 endTime; // The time when the session was ended (Unix timestamp).
+}
+
 /// @notice A helper function to work with unchecked iterators in loops.
 function uncheckedInc(uint256 i) pure returns (uint256 j) {
   unchecked {

--- a/src/Common.sol
+++ b/src/Common.sol
@@ -50,3 +50,12 @@ function uncheckedInc(uint256 i) pure returns (uint256 j) {
     j = i + 1;
   }
 }
+
+/// @dev Helper function to slice a byte array
+function slice(bytes memory data, uint256 start, uint256 length) pure returns (bytes memory) {
+  bytes memory result = new bytes(length);
+  for (uint i = 0; i < length; i++) {
+    result[i] = data[start + i];
+  }
+  return result;
+}

--- a/src/interfaces/IResolver.sol
+++ b/src/interfaces/IResolver.sol
@@ -57,4 +57,9 @@ interface IResolver {
   /// @param uid The UID of the schema.
   /// @param action The action that the role can perform on the schema.
   function setSchema(bytes32 uid, uint256 action) external;
+
+  function createSession(
+    uint256 duration,
+    string memory sessionTitle
+  ) external returns (bytes32 sessionId);
 }

--- a/src/resolver/Resolver.sol
+++ b/src/resolver/Resolver.sol
@@ -267,7 +267,7 @@ contract Resolver is IResolver, AccessControl {
   }
 
   /// @dev creates a new session
-  function sessionCreation(
+  function createSession(
     uint256 duration,
     string memory sessionTitle
   ) public returns (bytes32 sessionId) {
@@ -280,7 +280,7 @@ contract Resolver is IResolver, AccessControl {
     sessionId = keccak256(abi.encodePacked(msg.sender, sessionTitle));
 
     // Check if the session already exists
-    if (_session[sessionId].host != address(0)) {
+    if (_session[sessionId].host == address(0)) {
       revert InvalidSession();
     }
 
@@ -292,7 +292,14 @@ contract Resolver is IResolver, AccessControl {
       endTime: block.timestamp + sessionDuration
     });
 
+    //Store the session
     _session[sessionId] = session;
+
+    //Enable the host and attendee attestation related to the session
+    string memory hostAttestationTitle = string(abi.encodePacked("Host_", sessionTitle));
+    _allowedAttestationTitles[keccak256(abi.encode(hostAttestationTitle))] = true;
+    string memory attendeeAttestationTitle = string(abi.encodePacked("Attendee_", sessionTitle));
+    _allowedAttestationTitles[keccak256(abi.encode(attendeeAttestationTitle))] = true;
 
     return sessionId;
   }

--- a/src/resolver/Resolver.sol
+++ b/src/resolver/Resolver.sol
@@ -295,10 +295,9 @@ contract Resolver is IResolver, AccessControl {
     uint256 duration,
     string memory sessionTitle
   ) public returns (bytes32 sessionId) {
-    // Check if the caller is a Villager
-    if (!hasRole(VILLAGER_ROLE, msg.sender)) {
-      revert InvalidRole();
-    }
+    if (!hasRole(VILLAGER_ROLE, msg.sender)) revert InvalidRole();
+    if (duration == 0) revert InvalidSession();
+    if (bytes(sessionTitle).length == 0) revert InvalidSession();
 
     // Generate a unique session ID
     sessionId = keccak256(abi.encodePacked(msg.sender, sessionTitle));

--- a/src/resolver/Resolver.sol
+++ b/src/resolver/Resolver.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.4;
 import { IEAS, Attestation } from "../interfaces/IEAS.sol";
 import { IResolver } from "../interfaces/IResolver.sol";
 import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
-import { AccessDenied, InvalidEAS, InvalidLength, uncheckedInc, EMPTY_UID, NO_EXPIRATION_TIME } from "../Common.sol";
+import { AccessDenied, InvalidEAS, InvalidLength, uncheckedInc, EMPTY_UID, NO_EXPIRATION_TIME, Session } from "../Common.sol";
 
 error AlreadyHasResponse();
 error InsufficientValue();
@@ -40,6 +40,9 @@ contract Resolver is IResolver, AccessControl {
 
   // Maps schemas ID and role ID to action
   mapping(bytes32 => Action) private _allowedSchemas;
+
+  // Maps session Titles and sessions Structures
+  mapping(string => Session) private _session;
 
   // Maps all attestation titles (badge titles) to be retrieved by the frontend
   string[] private _attestationTitles;

--- a/test/Resolver.t.sol
+++ b/test/Resolver.t.sol
@@ -183,7 +183,7 @@ contract ResolverTest is Test {
 
     // Create a session
     vm.startPrank(host);
-    resolver.createSession(0, sessionTitle);
+    resolver.createSession(10, sessionTitle);
 
     // Prepare attestation data
     string memory hostTitle = string(abi.encodePacked("Host_", sessionTitle));
@@ -219,7 +219,7 @@ contract ResolverTest is Test {
 
     // Create a session
     vm.startPrank(host);
-    resolver.createSession(0, sessionTitle);
+    resolver.createSession(10, sessionTitle);
 
     // Prepare attestation data
     string memory hostTitle = string(abi.encodePacked("Host_", sessionTitle));


### PR DESCRIPTION
Pull request made to complete this task: https://github.com/orgs/blockful-io/projects/16/views/1?pane=issue&itemId=83822933&issue=blockful-io%7Cbackend-zucity%7C3

The context is that we will now have "session" in the contract. Each villager can create a session. Each session automatically creates two new badges that only the session host can attest.
To achieve this, the following items were added:

1. A map to store sessions (_session)
2. A function to create a session (createSession())
3. A function to check if the attestation is a session_attestation (isHostOnlyAttestation)
4. A function to check if the attester is the host (isAttesterHost)
5. A utility function slice() to get the first part of the attestation title
6. Tests to validate the functionality of the new code.